### PR TITLE
Fix compilation error, missing return value for copy constructor in cipepath.cc

### DIFF
--- a/source/src/cip/cipepath.cc
+++ b/source/src/cip/cipepath.cc
@@ -50,6 +50,8 @@ CipAppPath& CipAppPath::operator = ( const CipAppPath& other )
 
     if( HasSymbol() )
         memcpy( tag, other.tag, sizeof tag );
+
+    return *this;
 }
 
 


### PR DESCRIPTION
Fix compilation error, missing return value for copy constructor