### PR TITLE
Changed function type definitions to use std::function

### DIFF
--- a/source/src/cip/cipattribute.h
+++ b/source/src/cip/cipattribute.h
@@ -9,6 +9,7 @@
 #ifndef CIPATTRIBUTE_H_
 #define CIPATTRIBUTE_H_
 
+#include <functional>
 #include "ciptypes.h"
 
 class CipMessageRouterRequest;
@@ -18,8 +19,7 @@ class CipInstance;
 
 
 /** @ingroup CIP_API
- * @typedef  EipStatus (*AttributeFunc)( CipAttribute *,
- *    CipMessageRouterRequest*, CipMessageRouterResponse*)
+ * @typedef  std::function<EipStatus (CipAttribute*, CipMessageRouterRequest*, CipMessageRouterResponse*)> AttributeFunc
  *
  * @brief Signature definition for the implementation of CIP services.
  *
@@ -34,10 +34,8 @@ class CipInstance;
  * @return kEipStatusOk_SEND if service could be executed successfully and a response
  *  should be sent
  */
-typedef EipStatus (*AttributeFunc)( CipAttribute* aAttribute,
-            CipMessageRouterRequest* aRequest,
-            CipMessageRouterResponse* aResponse );
 
+typedef std::function<EipStatus (CipAttribute*, CipMessageRouterRequest*, CipMessageRouterResponse*)> AttributeFunc;
 
 
 /**

--- a/source/src/cip/cipconnection.h
+++ b/source/src/cip/cipconnection.h
@@ -128,14 +128,14 @@ enum ConnTimeoutMultiplier
  * @param aConn The connection object which is closing the
  * connection
  */
-typedef void (* ConnectionCloseFunction)( CipConn* aConn );
+typedef std::function<void (CipConn*)> ConnectionCloseFunction;
 
 /** @ingroup CIP_API
  * @brief Function prototype for handling the timeout of connections
  *
  * @param aConn The connection object which connection timed out
  */
-typedef void (* ConnectionTimeoutFunction)( CipConn* aConn );
+typedef std::function<void (CipConn*)> ConnectionTimeoutFunction;
 
 
 /**

--- a/source/src/cip/cipservice.h
+++ b/source/src/cip/cipservice.h
@@ -53,8 +53,7 @@ enum CIPServiceCode
 
 
 /**
- * Typedef EipStatus (*CipServiceFunc)( CipInstance *,
- *    CipMessageRouterRequest*, CipMessageRouterResponse*)
+ * Typedef std::function<EipStatus (CipInstance*, CipMessageRouterRequest*, CipMessageRouterResponse*)> CipServiceFunction
  * is the function type for the implementation of CIP services.
  *
  * CIP services have to follow this signature in order to be handled correctly
@@ -68,8 +67,7 @@ enum CIPServiceCode
  * @return EipStatus - EipOKSend if service could be executed successfully
  *    and a response should be sent.
  */
-typedef EipStatus (*CipServiceFunction)( CipInstance* aInstance,
-        CipMessageRouterRequest* aRequest, CipMessageRouterResponse* aResponse );
+typedef std::function<EipStatus (CipInstance*, CipMessageRouterRequest*, CipMessageRouterResponse*)> CipServiceFunction;
 
 
 /**


### PR DESCRIPTION
The function type definitions for AttributeFunc, CipServiceFunction, ConnectionCloseFunction and ConnectionTimeoutFunction were changed to use std::function type definitions so that lambdas and member functions can be used for the callbacks.