### PR TITLE
Bug fixes and enhancements

### DIFF
--- a/source/src/cip/cipassembly.cc
+++ b/source/src/cip/cipassembly.cc
@@ -49,7 +49,7 @@ CipAssemblyClass::CipAssemblyClass() :
         )
 {
     // Attribute 3 is the byte array transfer of the assembly data itself
-    AttributeInsert( _I, 3, get_assembly_data_attr, false, set_assembly_data_attr, memb_offs(byte_array) );
+    AttributeInsert( _I, 3, get_assembly_data_attr, false, set_assembly_data_attr, memb_offs(byte_array),  true, kCipByteArray);
 
     // Attribute 4: is no. of bytes in Attribute 3
     AttributeInsert( _I, 4, kCipByteArrayLength, memb_offs(byte_array), true, false );

--- a/source/src/cip/cipconnection.cc
+++ b/source/src/cip/cipconnection.cc
@@ -1030,7 +1030,10 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
 int CipConn::constructed_count;         // CipConn::instance_id is only for debugging
 
 CipConn::CipConn() :
-    instance_id( ++constructed_count )
+    instance_id( ++constructed_count ),
+    next(NULL),
+    prev(NULL),
+    on_list(false)
 {
     Clear( false );
 }

--- a/source/src/cip/cipconnectionmanager.cc
+++ b/source/src/cip/cipconnectionmanager.cc
@@ -420,7 +420,7 @@ bool CipConnBox::Remove( CipConn* aConn )
 
 bool IsConnectedInputAssembly( int aInstanceId )
 {
-    CipConn* c = g_active_conns.begin();
+    CipConnBox::iterator c = g_active_conns.begin();
 
     for(  ; c != g_active_conns.end();  ++c )
     {

--- a/source/src/cip/ciptypes.h
+++ b/source/src/cip/ciptypes.h
@@ -29,6 +29,7 @@ enum ClassIds
     kCipAssemblyClass           = 0x04,
     kCipConnectionClass         = 0x05,
     kCipConnectionManagerClass  = 0x06,
+    kCipRegisterClass           = 0x07,
     kCipTcpIpInterfaceClass     = 0xF5,
     kCipEthernetLinkClass       = 0xF6,
 };


### PR DESCRIPTION
1.  Fix a crash in Connection Manager for using the wrong type.

2.  Add Register Class Type

3.  Set default Assembly Type to kCipByteArray

4.  Initialize linked list pointers in CipConn class.