### PR TITLE
Fix Type Confusion in CorrectSizes causing invalid T->O size

### DIFF
--- a/source/src/cip/cipconnection.cc
+++ b/source/src/cip/cipconnection.cc
@@ -929,11 +929,11 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
         // an assembly object should always have an attribute 3
         CIPSTER_ASSERT( attribute );
 
-        ByteBuf* attr_data = (ByteBuf*) consuming_instance->Data( attribute );
+        int attr_size = static_cast<AssemblyInstance*>(consuming_instance)->SizeBytes();
 
         data_size    = consuming_ncp.ConnectionSize();
         diff_size    = 0;
-        is_heartbeat = ( attr_data->size() == 0 );
+        is_heartbeat = ( attr_size == 0 );
 
         if( trigger.Class() == kConnTransportClass1 )
         {
@@ -950,11 +950,11 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
             diff_size += 4;
         }
 
-        if( ( consuming_ncp.IsFixed() && data_size != attr_data->size() )
-          ||  data_size >  attr_data->size() )
+        if( ( consuming_ncp.IsFixed() && data_size != attr_size )
+          ||  data_size > attr_size )
         {
             // wrong connection size
-            corrected_consuming_size = attr_data->size() + diff_size;
+            corrected_consuming_size = attr_size + diff_size;
 
             *aExtError = kConnMgrStatusInvalidOToTConnectionSize;
 
@@ -962,7 +962,7 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
                 "%s: assembly size(%d) != requested conn_size(%d) for consuming:'%s'\n"
                 " corrected_o_t:%d\n",
                 __func__,
-                (int) attr_data->size(),
+                attr_size,
                 data_size,
                 ConsumingPath().Format().c_str(),
                 corrected_consuming_size
@@ -991,13 +991,13 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
         // an assembly object should always have an attribute 3
         CIPSTER_ASSERT( attribute );
 
-        ByteBuf* attr_data = (ByteBuf*) producing_instance->Data( attribute );
+        int attr_size = static_cast<AssemblyInstance*>(producing_instance)->SizeBytes();
 
         data_size    = producing_ncp.ConnectionSize();
         diff_size    = 0;
 
         // Note: spec never talks about a heartbeat t_o connection, so why this?
-        is_heartbeat = ( attr_data->size() == 0 );
+        is_heartbeat = ( attr_size == 0 );
 
         if( trigger.Class() == kConnTransportClass1 )
         {
@@ -1010,15 +1010,15 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
             // and is not kRealTimeFmtModeless
             && !is_heartbeat )
         {
-            data_size -= 4;   // remove the 4 bytes needed for run/idle header
+            data_size -= 4; // remove the 4 bytes needed for run/idle header
             diff_size += 4;
         }
 
-        if( ( producing_ncp.IsFixed() && data_size != attr_data->size() )
-          ||  data_size > attr_data->size() )
+        if( ( producing_ncp.IsFixed() && data_size != attr_size )
+          ||  data_size > attr_size )
         {
             // wrong connection size
-            corrected_producing_size = attr_data->size() + diff_size;
+            corrected_producing_size = attr_size + diff_size;
 
             *aExtError = kConnMgrStatusInvalidTToOConnectionSize;
 
@@ -1026,7 +1026,7 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
                 "%s: assembly size(%d) != requested conn_size(%d) for producing:'%s'\n"
                 " corrected_t_o:%d\n",
                 __func__,
-                (int) attr_data->size(),
+                attr_size,
                 data_size,
                 ProducingPath().Format().c_str(),
                 corrected_producing_size


### PR DESCRIPTION
**Bug Summary**
A critical Type Confusion vulnerability exists in `CorrectSizes()` (`src/cip/cipconnection.cc`) that causes the connection size validation to fail on 64-bit systems, resulting in valid `ForwardOpen` requests being rejected with `0x127` (invalid O->T connection size) or `0x128` (invalid T->O connection size) errors.

**Root Cause Analysis**
When fetching the actual size of the configured assembly instance, the code performs a C-style cast from `CipByteArray*` to `ByteBuf*`:

```cpp
// Original buggy code
ByteBuf* attr_data = (ByteBuf*) consuming_instance->Data( attribute );
int attr_size = attr_data->size();
```

However, `CipByteArray` and `ByteBuf` have completely incompatible memory layouts:
*   `CipByteArray` layout (approx 16-24 bytes depending on alignment): `uint8_t* start`, `uint16_t cap`, `uint16_t len`, `[Padding]`
*   `ByteBuf` layout (16 bytes): `uint8_t* start`, `uint8_t* limit`

When `attr_data->size()` (which is implemented as `limit - start`) is called, the compiler treats the `cap`, `len`, and subsequent padding bytes of the `CipByteArray` as a 64-bit `limit` pointer. This pointer arithmetic produces an astronomical garbage value (e.g., `1762171072`) instead of the true size (e.g., `128`). Consequently, the size check `data_size != attr_size` spuriously fails.

**Impact**
Legitimate Originators cannot establish Class 1 I/O connections because the Target always reports an invalid connection size.

**Fix Details**
Removed the unsafe `ByteBuf*` cast. Since I/O connection instances are inherently Assembly instances, the code now safely downcasts to `AssemblyInstance*` and directly invokes the built-in `SizeBytes()` method to retrieve the accurate assembly size.

```cpp
// Fixed code
int attr_size = static_cast<AssemblyInstance*>(consuming_instance)->SizeBytes();
```