### PR TITLE
fix: search all input and listen-only path candidates

### DIFF
--- a/source/src/cip/appcontype.cc
+++ b/source/src/cip/appcontype.cc
@@ -216,21 +216,26 @@ CipConn* ExclusiveOwner::GetConnection( ConnectionData* aConnData, ConnMgrStatus
 
 CipConn* InputOnlyConnSet::GetConnection( ConnectionData* aConnData, ConnMgrStatus* aExtError )
 {
+    bool output_matches = false;
+    bool input_matches = false;
+
     for( InputOnlyConnSet::iterator it = s_input_only.begin();  it != s_input_only.end();  ++it )
     {
         // we have the same output assembly?
         if( it->output_assembly == aConnData->ConsumingPath().GetInstanceOrConnPt() )
         {
+            output_matches = true;
+
             if( it->input_assembly != aConnData->ProducingPath().GetInstanceOrConnPt() )
             {
-                *aExtError = kConnMgrStatusInvalidProducingApplicationPath;
-                break;
+                continue;
             }
+
+            input_matches = true;
 
             if( it->config_assembly != aConnData->ConfigPath().GetInstanceOrConnPt() )
             {
-                *aExtError = kConnMgrStatusInconsistentApplicationPathCombo;
-                break;
+                continue;
             }
 
             CipConn* in = it->Alloc();
@@ -239,9 +244,14 @@ CipConn* InputOnlyConnSet::GetConnection( ConnectionData* aConnData, ConnMgrStat
                 return in;
 
             *aExtError = kConnMgrStatusTargetObjectOutOfConnections;
-            break;
+            return NULL;
         }
     }
+
+    if( input_matches )
+        *aExtError = kConnMgrStatusInconsistentApplicationPathCombo;
+    else if( output_matches )
+        *aExtError = kConnMgrStatusInvalidProducingApplicationPath;
 
     return NULL;
 }
@@ -257,27 +267,32 @@ CipConn* ListenOnlyConnSet::GetConnection( ConnectionData* aConnData, ConnMgrSta
         return NULL;
     }
 
+    bool output_matches = false;
+    bool input_matches = false;
+
     for( ListenOnlyConnSet::iterator it = s_listen_only.begin();  it != s_listen_only.end(); ++it )
     {
-                // we have the same output assembly?
+        // we have the same output assembly?
         if( it->output_assembly == aConnData->ConsumingPath().GetInstanceOrConnPt() )
         {
+            output_matches = true;
+
             if( it->input_assembly != aConnData->ProducingPath().GetInstanceOrConnPt() )
             {
-                *aExtError = kConnMgrStatusInvalidProducingApplicationPath;
-                break;
+                continue;
             }
+
+            input_matches = true;
 
             if( it->config_assembly != aConnData->ConfigPath().GetInstanceOrConnPt() )
             {
-                *aExtError = kConnMgrStatusInconsistentApplicationPathCombo;
-                break;
+                continue;
             }
 
             if( NULL == GetExistingProducerMulticastConnection( aConnData->ProducingPath().GetInstanceOrConnPt() ) )
             {
                 *aExtError = kConnMgrStatusNonListenOnlyConnectionNotOpened;
-                break;
+                return NULL;
             }
 
             CipConn* listener = it->Alloc();
@@ -286,9 +301,14 @@ CipConn* ListenOnlyConnSet::GetConnection( ConnectionData* aConnData, ConnMgrSta
                 return listener;
 
             *aExtError = kConnMgrStatusTargetObjectOutOfConnections;
-            break;
+            return NULL;
         }
     }
+
+    if( input_matches )
+        *aExtError = kConnMgrStatusInconsistentApplicationPathCombo;
+    else if( output_matches )
+        *aExtError = kConnMgrStatusInvalidProducingApplicationPath;
 
     return NULL;
 }


### PR DESCRIPTION
### Summary

This PR fixes order-dependent application path matching for Input Only and Listen Only connections. Connection lookup now examines all registered path candidates instead of stopping at the first entry that only partially matches the requested path.

### Problem

Input Only and Listen Only connection sets may contain multiple entries with the same consuming connection point but different producing or configuration connection points.

Previously, `InputOnlyConnSet::GetConnection()` and `ListenOnlyConnSet::GetConnection()` stopped searching as soon as they found an entry whose output assembly matched but whose input or configuration assembly did not. A valid full match later in the set was therefore never considered. Whether a Forward Open request succeeded depended on the order in which the application connection paths had been registered.

This could cause a valid CIP application path to be rejected with `Invalid Producing Application Path` or `Inconsistent Application Path Combination`, even though an exact registered path existed.

### Changes

- Continue searching after an Input Only or Listen Only candidate only partially matches the requested application path.
- Track partial output and input matches across the complete search so the existing extended error semantics are preserved when no exact match exists.
- Return exact-match resource and connection-state errors immediately, including `Target Object Out of Connections` and `Non-Listen Only Connection Not Opened`.
