### PR TITLE
fix: release I/O slots after failed Forward Open

### DIFF
--- a/source/src/cip/cipconnection.cc
+++ b/source/src/cip/cipconnection.cc
@@ -1346,6 +1346,7 @@ CipError CipConn::Activate( Cpf* aCpf, ConnMgrStatus* aExtError )
         if( kConnMgrStatusSuccess != *aExtError )
         {
             CIPSTER_TRACE_INFO( "%s: extended_error != 0\n", __func__ );
+            Clear( false );
             return kCipErrorConnectionFailure;
         }
     }
@@ -1359,6 +1360,14 @@ CipError CipConn::Activate( Cpf* aCpf, ConnMgrStatus* aExtError )
     if( result )
     {
         // CIPSTER_TRACE_ERR( "%s: openCommunicationChannels() failed.  \n", __func__ );
+
+        if( ConsumingUdp() )
+            UdpSocketMgr::ReleaseSocket( ConsumingUdp() );
+
+        if( ProducingUdp() )
+            UdpSocketMgr::ReleaseSocket( ProducingUdp() );
+
+        Clear( false );
         return result;
     }
 


### PR DESCRIPTION
### Summary

This PR prevents failed Input Only and Listen Only Forward Open requests from permanently consuming preallocated connection slots.

### Problem

Input Only and Listen Only connection slots are reserved before activation by changing their state from `NonExistent` to `Configuring`. If `CipConn::Activate()` subsequently failed while applying configuration data or opening the communication channels, it returned without restoring the slot state.

Because allocation only considers slots in the `NonExistent` state, every failed request permanently removed one slot from the pool. Repeating a Forward Open request that reached activation but failed could eventually exhaust all slots for an otherwise valid application path. Later requests would then fail with `Target Object Out of Connections`, even though no connections had been established.

Failures after opening one communication direction could also leave a UDP socket reference attached to the unestablished connection.

### Changes

- Reset an unestablished connection when configuration data handling fails during activation.
- Release any consuming or producing UDP sockets acquired before communication channel setup fails.
- Clear the failed connection's runtime state without emitting close notifications intended for established connections.