### PR TITLE
fix: validate connection sizes using Assembly data length

### DIFF
--- a/source/src/cip/cipconnection.cc
+++ b/source/src/cip/cipconnection.cc
@@ -925,15 +925,12 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
         // Vol1 3-5.4.1.10.2 Assumed Assembly Object Attribute (== 3)
         ConsumingPath().SetAttribute( 3 );
 
-        CipAttribute* attribute = consuming_instance->Attribute( 3 );
-        // an assembly object should always have an attribute 3
-        CIPSTER_ASSERT( attribute );
-
-        ByteBuf* attr_data = (ByteBuf*) consuming_instance->Data( attribute );
+        const int assembly_size =
+            static_cast<AssemblyInstance*>( consuming_instance )->SizeBytes();
 
         data_size    = consuming_ncp.ConnectionSize();
         diff_size    = 0;
-        is_heartbeat = ( attr_data->size() == 0 );
+        is_heartbeat = ( assembly_size == 0 );
 
         if( trigger.Class() == kConnTransportClass1 )
         {
@@ -950,11 +947,11 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
             diff_size += 4;
         }
 
-        if( ( consuming_ncp.IsFixed() && data_size != attr_data->size() )
-          ||  data_size >  attr_data->size() )
+        if( ( consuming_ncp.IsFixed() && data_size != assembly_size )
+          ||  data_size > assembly_size )
         {
             // wrong connection size
-            corrected_consuming_size = attr_data->size() + diff_size;
+            corrected_consuming_size = assembly_size + diff_size;
 
             *aExtError = kConnMgrStatusInvalidOToTConnectionSize;
 
@@ -962,7 +959,7 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
                 "%s: assembly size(%d) != requested conn_size(%d) for consuming:'%s'\n"
                 " corrected_o_t:%d\n",
                 __func__,
-                (int) attr_data->size(),
+                assembly_size,
                 data_size,
                 ConsumingPath().Format().c_str(),
                 corrected_consuming_size
@@ -986,18 +983,14 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
         // Vol1 3-5.4.1.10.2 Assumed Assembly Object Attribute (== 3)
         ProducingPath().SetAttribute( 3 );
 
-        CipAttribute* attribute = producing_instance->Attribute( 3 );
-
-        // an assembly object should always have an attribute 3
-        CIPSTER_ASSERT( attribute );
-
-        ByteBuf* attr_data = (ByteBuf*) producing_instance->Data( attribute );
+        const int assembly_size =
+            static_cast<AssemblyInstance*>( producing_instance )->SizeBytes();
 
         data_size    = producing_ncp.ConnectionSize();
         diff_size    = 0;
 
         // Note: spec never talks about a heartbeat t_o connection, so why this?
-        is_heartbeat = ( attr_data->size() == 0 );
+        is_heartbeat = ( assembly_size == 0 );
 
         if( trigger.Class() == kConnTransportClass1 )
         {
@@ -1014,11 +1007,11 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
             diff_size += 4;
         }
 
-        if( ( producing_ncp.IsFixed() && data_size != attr_data->size() )
-          ||  data_size > attr_data->size() )
+        if( ( producing_ncp.IsFixed() && data_size != assembly_size )
+          ||  data_size > assembly_size )
         {
             // wrong connection size
-            corrected_producing_size = attr_data->size() + diff_size;
+            corrected_producing_size = assembly_size + diff_size;
 
             *aExtError = kConnMgrStatusInvalidTToOConnectionSize;
 
@@ -1026,7 +1019,7 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
                 "%s: assembly size(%d) != requested conn_size(%d) for producing:'%s'\n"
                 " corrected_t_o:%d\n",
                 __func__,
-                (int) attr_data->size(),
+                assembly_size,
                 data_size,
                 ProducingPath().Format().c_str(),
                 corrected_producing_size


### PR DESCRIPTION
### Summary

This PR fixes Forward Open connection-size validation after Assembly Attribute 3 was migrated from `ByteBuf` to `CipByteArray`. O-to-T and T-to-O sizes are now validated against the Assembly instance's actual logical data length.

### Problem

`ConnectionData::CorrectSizes()` still treated the backing storage of Assembly Attribute 3 as a `ByteBuf`. The attribute is now backed by `CipByteArray`, whose object layout stores a data pointer, capacity, and logical length instead of the start and limit pointers expected by `ByteBuf`.

Casting the attribute data to `ByteBuf*` therefore caused `ByteBuf::size()` to perform pointer arithmetic on fields that were not pointers. This could produce an invalid Assembly size or undefined behavior during Forward Open processing. As a result, valid Class 0/1 connections could be rejected with `Invalid O-to-T Connection Size` or `Invalid T-to-O Connection Size`, and the corrected size returned to the originator could also be incorrect.

### Changes

- Replace the invalid `CipByteArray`-to-`ByteBuf` casts in `ConnectionData::CorrectSizes()`.
- Obtain consuming and producing Assembly lengths through `AssemblyInstance::SizeBytes()`.
- Use the real Assembly length for heartbeat detection and fixed/variable connection-size validation.
- Calculate corrected O-to-T and T-to-O connection sizes from the actual Attribute 3 length.
