### PR TITLE
fix: reject connection sizes below protocol overhead

### DIFF
--- a/source/src/cip/cipconnection.cc
+++ b/source/src/cip/cipconnection.cc
@@ -937,7 +937,6 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
 
         if( trigger.Class() == kConnTransportClass1 )
         {
-            data_size -= 2;     // remove 16-bit sequence count length
             diff_size += 2;
         }
 
@@ -946,9 +945,27 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
             // and is not kRealTimeFmtModeless
             && !is_heartbeat )
         {
-            data_size -= 4;     // remove the 4 bytes needed for run/idle header
             diff_size += 4;
         }
+
+        if( data_size < diff_size )
+        {
+            corrected_consuming_size = attr_data->size() + diff_size;
+            *aExtError = kConnMgrStatusInvalidOToTConnectionSize;
+
+            CIPSTER_TRACE_INFO(
+                "%s: requested conn_size(%d) is smaller than required overhead(%d)"
+                " for consuming:'%s'\n",
+                __func__,
+                data_size,
+                diff_size,
+                ConsumingPath().Format().c_str()
+                );
+
+            return kCipErrorConnectionFailure;
+        }
+
+        data_size -= diff_size;
 
         if( ( consuming_ncp.IsFixed() && data_size != attr_data->size() )
           ||  data_size >  attr_data->size() )
@@ -1001,7 +1018,6 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
 
         if( trigger.Class() == kConnTransportClass1 )
         {
-            data_size -= 2; // remove 16-bit sequence count length
             diff_size += 2;
         }
 
@@ -1010,9 +1026,27 @@ CipError ConnectionData::CorrectSizes( ConnMgrStatus* aExtError )
             // and is not kRealTimeFmtModeless
             && !is_heartbeat )
         {
-            data_size -= 4;   // remove the 4 bytes needed for run/idle header
             diff_size += 4;
         }
+
+        if( data_size < diff_size )
+        {
+            corrected_producing_size = attr_data->size() + diff_size;
+            *aExtError = kConnMgrStatusInvalidTToOConnectionSize;
+
+            CIPSTER_TRACE_INFO(
+                "%s: requested conn_size(%d) is smaller than required overhead(%d)"
+                " for producing:'%s'\n",
+                __func__,
+                data_size,
+                diff_size,
+                ProducingPath().Format().c_str()
+                );
+
+            return kCipErrorConnectionFailure;
+        }
+
+        data_size -= diff_size;
 
         if( ( producing_ncp.IsFixed() && data_size != attr_data->size() )
           ||  data_size > attr_data->size() )


### PR DESCRIPTION
### Summary

This PR rejects variable-length I/O connections whose requested Connection Size is smaller than the protocol overhead required by their Transport Class and Real-Time Format.

### Problem

`ConnectionData::CorrectSizes()` converted the requested network Connection Size to an `int` and then subtracted the Class 1 sequence count and, when applicable, the 32-bit Real-Time Header before validating the remaining Assembly payload size.

If the requested size was smaller than those headers, the subtraction produced a negative payload size. Fixed-size connections were rejected by the equality check, but variable-size connections only checked whether the payload size exceeded the Assembly size. A negative value never exceeded the Assembly size, so an undersized request could be accepted.

This allowed a Forward Open request to establish a connection whose negotiated size could not contain its required protocol headers, causing the negotiated size and subsequent I/O packet layout to disagree.

### Changes

- Calculate the complete required protocol overhead before subtracting it from the requested Connection Size.
- Reject O-to-T sizes smaller than the required overhead with `Invalid O-to-T Connection Size`.
- Reject T-to-O sizes smaller than the required overhead with `Invalid T-to-O Connection Size`.
- Return the existing corrected connection size for rejected requests.
