### PR TITLE
fix: enforce Assembly data write access

### DIFF
--- a/source/src/cip/appcontype.cc
+++ b/source/src/cip/appcontype.cc
@@ -9,6 +9,34 @@
 
 #include "appcontype.h"
 #include <cipster_api.h>            // NotifyIoConnectionEvent()
+#include "cipassembly.h"
+
+
+static void AddAssemblyConnectionPointRole( int aInstanceId,
+        AssemblyInstance::ConnectionPointRole aRole )
+{
+    if( aInstanceId < 0 )
+        return;
+
+    CipClass* assembly_class = GetCipClass( kCipAssemblyClass );
+    if( !assembly_class )
+        return;
+
+    AssemblyInstance* assembly = static_cast<AssemblyInstance*>(
+            assembly_class->Instance( aInstanceId ) );
+
+    if( assembly )
+        assembly->AddConnectionPointRole( aRole );
+}
+
+
+static void AddAssemblyConnectionPointRoles( int aOutputAssembly,
+        int aInputAssembly, int aConfigAssembly )
+{
+    AddAssemblyConnectionPointRole( aOutputAssembly, AssemblyInstance::kRoleConsumed );
+    AddAssemblyConnectionPointRole( aInputAssembly, AssemblyInstance::kRoleProduced );
+    AddAssemblyConnectionPointRole( aConfigAssembly, AssemblyInstance::kRoleConfiguration );
+}
 
 /**
  * Class ExclusiveOwner
@@ -299,7 +327,13 @@ bool ConfigureExclusiveOwnerConnectionPoint(
         int input_assembly,
         int config_assembly )
 {
-    return ExclusiveOwner::AddExpectation( output_assembly, input_assembly, config_assembly );
+    bool added = ExclusiveOwner::AddExpectation(
+            output_assembly, input_assembly, config_assembly );
+
+    if( added )
+        AddAssemblyConnectionPointRoles( output_assembly, input_assembly, config_assembly );
+
+    return added;
 }
 
 
@@ -308,7 +342,13 @@ bool ConfigureInputOnlyConnectionPoint(
         int input_assembly,
         int config_assembly )
 {
-    return InputOnlyConnSet::AddExpectation( output_assembly, input_assembly, config_assembly );
+    bool added = InputOnlyConnSet::AddExpectation(
+            output_assembly, input_assembly, config_assembly );
+
+    if( added )
+        AddAssemblyConnectionPointRoles( output_assembly, input_assembly, config_assembly );
+
+    return added;
 }
 
 
@@ -317,7 +357,13 @@ bool ConfigureListenOnlyConnectionPoint(
         int input_assembly,
         int config_assembly )
 {
-    return ListenOnlyConnSet::AddExpectation( output_assembly, input_assembly, config_assembly );
+    bool added = ListenOnlyConnSet::AddExpectation(
+            output_assembly, input_assembly, config_assembly );
+
+    if( added )
+        AddAssemblyConnectionPointRoles( output_assembly, input_assembly, config_assembly );
+
+    return added;
 }
 
 

--- a/source/src/cip/cipassembly.cc
+++ b/source/src/cip/cipassembly.cc
@@ -20,7 +20,8 @@ AssemblyInstance::AssemblyInstance( int aInstanceId, ByteBuf aBuffer ) :
     CipInstance( aInstanceId ),
     // The assembly's ByteBuf spans the full application-owned allocation, so its size
     // is the true capacity (capacity == length for a fixed assembly buffer).
-    byte_array( aBuffer.data(), (uint16_t) aBuffer.size() )
+    byte_array( aBuffer.data(), (uint16_t) aBuffer.size() ),
+    connection_point_roles( kRoleNone )
 {
 }
 
@@ -126,9 +127,15 @@ EipStatus CipAssemblyClass::set_assembly_data_attr( CipInstance* aInstance, CipA
 {
     AssemblyInstance* assembly = static_cast<AssemblyInstance*>( aInstance );
 
-    if( IsConnectedInputAssembly( assembly->Id() ) )
+    if( assembly->HasConnectionPointRole( AssemblyInstance::kRoleProduced ) )
     {
-        CIPSTER_TRACE_WARN( "%s: received data for connected input assembly\n", __func__ );
+        CIPSTER_TRACE_WARN( "%s: cannot set produced assembly data\n", __func__ );
+        response->SetGenStatus( kCipErrorAttributeNotSetable );
+    }
+    else if( assembly->HasConnectionPointRole( AssemblyInstance::kRoleConsumed )
+          && IsConnectedOutputAssembly( assembly->Id() ) )
+    {
+        CIPSTER_TRACE_WARN( "%s: received data for connected output assembly\n", __func__ );
         response->SetGenStatus( kCipErrorAttributeNotSetable );
     }
     else if( request->Data().size() < assembly->byte_array.size() )

--- a/source/src/cip/cipassembly.h
+++ b/source/src/cip/cipassembly.h
@@ -22,6 +22,14 @@ class AssemblyInstance : public CipInstance
 {
     friend class CipAssemblyClass;
 public:
+    enum ConnectionPointRole
+    {
+        kRoleNone          = 0,
+        kRoleConsumed      = 1,    ///< O-to-T Output Assembly
+        kRoleProduced      = 2,    ///< T-to-O Input Assembly
+        kRoleConfiguration = 4     ///< Configuration Assembly
+    };
+
     AssemblyInstance( int aInstanceId, ByteBuf aBuf );
 
     unsigned SizeBytes() const      { return byte_array.size(); }
@@ -29,6 +37,16 @@ public:
     /// Return a ByteBuf view spanning the assembly's valid bytes.  Returned by value
     /// (not a reference to the member) because the member is now a CipByteArray.
     ByteBuf Buffer() const          { return ByteBuf( byte_array.data(), byte_array.length() ); }
+
+    void AddConnectionPointRole( ConnectionPointRole aRole )
+    {
+        connection_point_roles |= aRole;
+    }
+
+    bool HasConnectionPointRole( ConnectionPointRole aRole ) const
+    {
+        return 0 != ( connection_point_roles & aRole );
+    }
 
     /**
      * Function RecvData
@@ -49,6 +67,7 @@ public:
 
 protected:
     CipByteArray    byte_array;
+    unsigned        connection_point_roles;
 };
 
 


### PR DESCRIPTION
### Summary

This PR enforces the correct Attribute 3 write policy for Produced/Input and Consumed/Output Assembly instances.

Produced Assemblies are now read-only through `Set_Attribute_Single`, while Consumed Assemblies remain explicitly writable only when they are not owned by an active implicit I/O connection.

### Problem

Assembly Attribute 3 used a shared writable attribute descriptor for every Assembly instance, but the stack did not record whether an instance was used as a Produced, Consumed, or Configuration connection point.

The setter attempted to protect connected Assembly data by calling `IsConnectedInputAssembly()`. That function checks the connection's producing path, so the resulting behavior was reversed and incomplete:

- A Produced/Input Assembly was blocked only while connected and became explicitly writable after the connection closed, even though its data is target-produced and should be read-only to explicit clients.
- A Consumed/Output Assembly was not protected while an active O-to-T connection owned it, allowing explicit writes to race with implicit I/O data.
- Configuration and standalone explicit Assemblies inherited the same undifferentiated policy.

This allowed explicit messages to overwrite Produced data or interfere with Output data controlled by an active I/O connection.

### Changes

- Add per-instance connection-point role tracking for Consumed, Produced, and Configuration Assemblies.
- Record Assembly roles when an Exclusive Owner, Input Only, or Listen Only connection point is successfully configured.
- Reject Attribute 3 writes to every Produced/Input Assembly with `Attribute Not Settable`.
- Reject Attribute 3 writes to a Consumed/Output Assembly while it participates in an active O-to-T connection.
